### PR TITLE
fix: redis.helper.test add in the second parameter here too

### DIFF
--- a/__tests__/utils/redis.helper.test.js
+++ b/__tests__/utils/redis.helper.test.js
@@ -22,7 +22,7 @@ describe('Unit tests - redis.helper', () => {
     test('should require and invoce redis', () => {
         require('../../src/utils/redis.helper');
 
-        expect(redis.createClient).toHaveBeenCalledWith(process.env.REDIS_PORT);
+        expect(redis.createClient).toHaveBeenCalledWith(process.env.REDIS_PORT, process.env.REDIS_HOST || "localhost");
     });
 
     test('should already have a redis instance', () => {


### PR DESCRIPTION
Checking out your tests, it seems this was missing. Hope this helps! :)